### PR TITLE
Add January 2017 talk

### DIFF
--- a/talks.md
+++ b/talks.md
@@ -2,6 +2,9 @@
 
 ## 2017
 
+### January
+* RSA Encryption Algorithm - Allen Poapst
+
 ### February
 * [Buying/Selling Websites/Web Businesses](https://rawgit.com/timginn/devtrx-buysell/master/index.html#/) - [Tim Ginn](https://github.com/timginn)
 * Publishing a WordPress Theme - Rose Merry


### PR DESCRIPTION
The January 2017 DevTricks almost never happened... it was snowy, and only a handful of people turned up. I co-ordinated it, and wasn't aware that Allen had told someone the month before that he had a talk planned for January.

Does anyone have a github profile or personal website to link for Allen? If not, I'll just merge as-is.